### PR TITLE
Add SourceLink and Symbol package generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/src/.idea

--- a/src/ECB.Data.ExchangeRates/ECB.Data.ExchangeRates.csproj
+++ b/src/ECB.Data.ExchangeRates/ECB.Data.ExchangeRates.csproj
@@ -16,6 +16,8 @@
     <PackageTags>currency currency-exchange currency-rates exchange-rates currency-exchange-rates ecb european-central-bank</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Description>Provides access to the EXR Dataflow (currency exchange rates) of ECB Data Portal web services (https://data.ecb.europa.eu).</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>Added method overloads with cancellation token parameter</PackageReleaseNotes>

--- a/src/ECB.Data.ExchangeRates/ECB.Data.ExchangeRates.csproj
+++ b/src/ECB.Data.ExchangeRates/ECB.Data.ExchangeRates.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -18,6 +18,8 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	 <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <Description>Provides access to the EXR Dataflow (currency exchange rates) of ECB Data Portal web services (https://data.ecb.europa.eu).</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>Added method overloads with cancellation token parameter</PackageReleaseNotes>
@@ -29,7 +31,10 @@
     <None Remove="README.md" />
   </ItemGroup>
 
-  <ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework) == 'net5.0'" />
+	</ItemGroup>
+	<ItemGroup>
     <Content Include="icon.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>


### PR DESCRIPTION
This PR adds SourceLink support as well as Symbols package generation.

If you build the package using the ``dotnet pack`` command then just append ``--include-symbols`` and ``--include-sources``. 

To add the Symbols package to NuGet gallery's symbol server just upload/push the ``.snupkg`` symbols package when you upload/push the corresponding ``.nupkg`` package version.

``Microsoft.SourceLink.GitHub`` is added as a dev dependency but it is not consumed by the client ([read more here](https://github.com/dotnet/sourcelink/blob/main/README.md)). It's not needed from .NET 8 onwards hence why I've added .NET 8 TFM as a target and limited the dev dependency package usage to older TFMs.

Let me know if you have any questions and thanks again.