### PR TITLE
Update test dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
     - name: Restore dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/src/.idea

--- a/src/ECB.Data.ExchangeRates.Tests/ECB.Data.ExchangeRates.Tests.csproj
+++ b/src/ECB.Data.ExchangeRates.Tests/ECB.Data.ExchangeRates.Tests.csproj
@@ -4,19 +4,18 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ECB.Data.ExchangeRates.Tests/TestRequests.cs
+++ b/src/ECB.Data.ExchangeRates.Tests/TestRequests.cs
@@ -50,7 +50,7 @@ public class TestRequests
 			Parser
 		);
 
-		await client.GetDailyAverageRatesAsync(currencies);
+		await client.GetDailyAverageRatesAsync(currencies, TestContext.Current.CancellationToken);
 	}
 
 	[Theory]
@@ -74,7 +74,7 @@ public class TestRequests
 			Parser
 		);
 
-		await client.GetDailyAverageRatesAsync(new DateTime(2002, 1, 2), currencies);
+		await client.GetDailyAverageRatesAsync(new DateTime(2002, 1, 2), currencies, TestContext.Current.CancellationToken);
 	}
 
 	[Theory]
@@ -98,11 +98,12 @@ public class TestRequests
 			Parser
 		);
 
-		await client.GetDailyAverageRatesAsync(
-			new DateTime(2002, 1, 2),
-			new DateTime(2003, 12, 31),
-			currencies
-		);
+		await client.GetDailyAverageRatesAsync(new DateTime(2002,
+				1, 2),
+			new DateTime(2003,
+				12, 31),
+			currencies,
+			TestContext.Current.CancellationToken);
 	}
 
 	[Theory]
@@ -126,7 +127,7 @@ public class TestRequests
 			Parser
 		);
 
-		await client.GetMonthlyAverageRatesAsync(1, 2002, currencies);
+		await client.GetMonthlyAverageRatesAsync(1, 2002, currencies, TestContext.Current.CancellationToken);
 	}
 
 	[Theory]
@@ -150,7 +151,7 @@ public class TestRequests
 			Parser
 		);
 
-		await client.GetMonthlyAverageRatesAsync(1, 2002, 12, 2003, currencies);
+		await client.GetMonthlyAverageRatesAsync(1, 2002, 12, 2003, currencies, TestContext.Current.CancellationToken);
 	}
 
 	[Theory]
@@ -174,7 +175,7 @@ public class TestRequests
 			Parser
 		);
 
-		await client.GetAnnualAverageRatesAsync(2002, currencies);
+		await client.GetAnnualAverageRatesAsync(2002, currencies, TestContext.Current.CancellationToken);
 	}
 
 	[Theory]
@@ -198,7 +199,7 @@ public class TestRequests
 			Parser
 		);
 
-		await client.GetAnnualAverageRatesAsync(2002, 2003, currencies);
+		await client.GetAnnualAverageRatesAsync(2002, 2003, currencies, TestContext.Current.CancellationToken);
 	}
 }
 

--- a/src/ECB.Data.ExchangeRates.Tests/TestResults.cs
+++ b/src/ECB.Data.ExchangeRates.Tests/TestResults.cs
@@ -37,7 +37,7 @@ public class TestResults
 			)
 		);
 
-		var rates = await client.GetDailyAverageRatesAsync();
+		var rates = await client.GetDailyAverageRatesAsync([], TestContext.Current.CancellationToken);
 
 		Assert.Empty(rates);
 	}
@@ -73,7 +73,7 @@ public class TestResults
 			)
 		);
 
-		var rates = await client.GetDailyAverageRatesAsync();
+		var rates = await client.GetDailyAverageRatesAsync([], TestContext.Current.CancellationToken);
 
 		var rate = Assert.Single(rates);
 		Assert.Equal("D", rate.Frequency);
@@ -120,7 +120,7 @@ public class TestResults
 			)
 		);
 
-		var rates = await client.GetDailyAverageRatesAsync();
+		var rates = await client.GetDailyAverageRatesAsync([], TestContext.Current.CancellationToken);
 
 		Assert.Collection(
 			rates,
@@ -191,7 +191,7 @@ public class TestResults
 			)
 		);
 
-		var rates = await client.GetDailyAverageRatesAsync();
+		var rates = await client.GetDailyAverageRatesAsync([], TestContext.Current.CancellationToken);
 
 		Assert.Collection(
 			rates,
@@ -270,7 +270,7 @@ public class TestResults
 			)
 		);
 
-		var rates = await client.GetDailyAverageRatesAsync();
+		var rates = await client.GetDailyAverageRatesAsync([], TestContext.Current.CancellationToken);
 
 		Assert.Collection(
 			rates,


### PR DESCRIPTION
This PR updates test project dependencies and updates XUnit to XUnit v3 version 3.2.2 (original XUnit package is deprecated and stuck at v2) and adds dependabot to keep dependencies up to date.