### PR TITLE
Use Async code path in .NET 5+, add null coalesing and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/src/.idea

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesClient.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesClient.cs
@@ -545,11 +545,15 @@ public class ExchangeRatesClient : HttpClient
 	private async Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync(string frequency, string[] currencies, string parameters, CancellationToken cancellationToken)
 	{
 		var response = (await GetAsync($"{frequency}.{string.Join("+", currencies)}.EUR.SP00.A?detail=dataOnly{parameters}", HttpCompletionOption.ResponseHeadersRead, cancellationToken)).EnsureSuccessStatusCode();
-		using var stream = await response.Content.ReadAsStreamAsync(
-#if NET5_0_OR_GREATER
-			cancellationToken
+		// await using uses IAsyncDisposable instead of IDisposable
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
+		await
 #endif
-		);
+			using var stream = await response.Content.ReadAsStreamAsync(
+#if NET5_0_OR_GREATER
+				cancellationToken
+#endif
+			);
 		return await _parser.ParseAsync(stream, cancellationToken);
 	}
 }

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesClient.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesClient.cs
@@ -292,7 +292,12 @@ public class ExchangeRatesClient : HttpClient
 	///	</exception>
 	public async Task<IEnumerable<ExchangeRate>> GetDailyAverageRatesAsync(DateTime startDate, DateTime endDate, string[] currencies, CancellationToken cancellationToken)
 	{
+#if NET8_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(currencies);		
+#else
 		if (currencies == null) throw new ArgumentNullException(nameof(currencies));
+#endif
+		
 		return await GetExchangeRatesAsync(MEASUREMENT_FREQUENCY_DAILY, currencies, $"&startPeriod={startDate:yyyy-MM-dd}&endPeriod={endDate:yyyy-MM-dd}", cancellationToken);
 	}
 
@@ -413,7 +418,11 @@ public class ExchangeRatesClient : HttpClient
 	///	</exception>
 	public async Task<IEnumerable<ExchangeRate>> GetMonthlyAverageRatesAsync(int startMonth, int startYear, int endMonth, int endYear, string[] currencies, CancellationToken cancellationToken)
 	{
+#if NET8_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(currencies);		
+#else
 		if (currencies == null) throw new ArgumentNullException(nameof(currencies));
+#endif
 		return await GetExchangeRatesAsync(MEASUREMENT_FREQUENCY_MONTHLY, currencies, $"&startPeriod={startYear:D4}-{startMonth:D2}&endPeriod={endYear:D4}-{endMonth:D2}", cancellationToken);
 	}
 
@@ -520,7 +529,12 @@ public class ExchangeRatesClient : HttpClient
 	///	</exception>
 	public async Task<IEnumerable<ExchangeRate>> GetAnnualAverageRatesAsync(int startYear, int endYear, string[] currencies, CancellationToken cancellationToken)
 	{
+#if NET8_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(currencies);
+#else
 		if (currencies == null) throw new ArgumentNullException(nameof(currencies));
+#endif
+		
 		return await GetExchangeRatesAsync(MEASUREMENT_FREQUENCY_ANNUAL, currencies, $"&startPeriod={startYear:D4}&endPeriod={endYear:D4}", cancellationToken);
 	}
 

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
@@ -71,7 +71,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 			throw;
 		}
 
-		return Parse(document);
+		return ParseDocument(document);
 	}
 
 	/// <summary>
@@ -105,14 +105,14 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 			throw;
 		}
 
-		return Parse(document);
+		return ParseDocument(document);
 #else
 		cancellationToken.ThrowIfCancellationRequested();
 		return Parse(stream);
 #endif
 	}
 
-	private static IEnumerable<ExchangeRate> Parse(XDocument document)
+	private static IEnumerable<ExchangeRate> ParseDocument(XDocument document)
 	{
 		var genericNamespace = document.Root?.GetNamespaceOfPrefix("generic")
 		                       ?? throw new XmlException("The namespace of the prefix 'generic' is missing.");

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
@@ -71,7 +71,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 			throw;
 		}
 
-		return ParseDocument(document);
+		return Parse(document);
 	}
 
 	/// <summary>
@@ -105,14 +105,14 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 			throw;
 		}
 
-		return ParseDocument(document);
+		return Parse(document);
 #else
 		cancellationToken.ThrowIfCancellationRequested();
 		return Parse(stream);
 #endif
 	}
 
-	private static IEnumerable<ExchangeRate> ParseDocument(XDocument document)
+	private static IEnumerable<ExchangeRate> Parse(XDocument document)
 	{
 		var genericNamespace = document.Root?.GetNamespaceOfPrefix("generic")
 		                       ?? throw new XmlException("The namespace of the prefix 'generic' is missing.");

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
@@ -172,7 +172,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 	}
 }
 
-#if !NETSTANDARD2_1_OR_GREATER
+#if !NETSTANDARD2_1 && !NET5_0_OR_GREATER
 internal static class Extensions
 {
 	public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
@@ -56,7 +56,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 	/// <returns>The currency exchange rates.</returns>
 	/// <exception cref="XmlException">
 	///     The response content does not contain a valid XML document or
-	///     does not contain the namespace of prefix 'generic'.
+	///     does not contain the namespace prefix 'generic'.
 	/// </exception>
 	public IEnumerable<ExchangeRate> Parse(Stream stream)
 	{
@@ -75,7 +75,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 	}
 
 	/// <summary>
-	///     Parses asynchronously the response of an HTTP request to ECB Data
+	///     Asynchronously parses the response of an HTTP request to ECB Data
 	///     Portal web services.
 	/// </summary>
 	/// <param name="stream">The stream that contains the XML response to
@@ -89,7 +89,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 	///	</exception>
 	/// <exception cref="XmlException">
 	///     The response content does not contain a valid XML document or
-	///     does not contain the namespace of prefix 'generic'.
+	///     does not contain the namespace prefix 'generic'.
 	/// </exception>
 	public async Task<IEnumerable<ExchangeRate>> ParseAsync(Stream stream, CancellationToken cancellationToken)
 	{
@@ -115,7 +115,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 	private static IEnumerable<ExchangeRate> Parse(XDocument document)
 	{
 		var genericNamespace = document.Root!.GetNamespaceOfPrefix("generic")
-			?? throw new XmlException("Namespace of prefix 'generic' is missing.");
+		                       ?? throw new XmlException("The namespace of the prefix 'generic' is missing.");
 
 		var seriesKeyValueName = XName.Get("Value", genericNamespace.NamespaceName);
 		var obsName = XName.Get("Obs", genericNamespace.NamespaceName);

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
@@ -114,7 +114,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 
 	private static IEnumerable<ExchangeRate> Parse(XDocument document)
 	{
-		var genericNamespace = document.Root!.GetNamespaceOfPrefix("generic")
+		var genericNamespace = document.Root?.GetNamespaceOfPrefix("generic")
 		                       ?? throw new XmlException("The namespace of the prefix 'generic' is missing.");
 
 		var seriesKeyValueName = XName.Get("Value", genericNamespace.NamespaceName);
@@ -128,7 +128,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 				{
 					var seriesKeyValues = a.Descendants(seriesKeyValueName)
 						.ToDictionary(
-							b => b.Attribute("id")!.Value,
+							b => b.Attribute("id")?.Value ?? throw new ArgumentException("Cannot find series key."),
 							b => b.Attribute("value")?.Value
 						);
 					return new

--- a/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
+++ b/src/ECB.Data.ExchangeRates/ExchangeRatesParser.cs
@@ -93,7 +93,7 @@ public class ExchangeRatesParser : IExchangeRatesParser, IAsyncExchangeRatesPars
 	/// </exception>
 	public async Task<IEnumerable<ExchangeRate>> ParseAsync(Stream stream, CancellationToken cancellationToken)
 	{
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
 		XDocument document;
 		try
 		{

--- a/src/ECB.Data.ExchangeRates/IAsyncExchangeRatesParser.cs
+++ b/src/ECB.Data.ExchangeRates/IAsyncExchangeRatesParser.cs
@@ -30,7 +30,7 @@ namespace ECB.Data.ExchangeRates;
 public interface IAsyncExchangeRatesParser
 {
 	/// <summary>
-	///     Parses asynchronously the response of an HTTP request to ECB Data
+	///     Asynchronously parses the response of an HTTP request to ECB Data
 	///     Portal web services.
 	/// </summary>
 	/// <param name="stream">The stream that contains the XML response to

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
This PR replaces some nullability ignore warnings ``!`` with null coalesing, updates the extension method fallback to just be for .NET Standard 2.0, allows .NET 5+ to use the Async path in ``ParseAsync``, and uses IAsyncDisposable's ``await using`` in GetExchangeRates where supported.

I suggest renaming the private ``Parse(XDocument)`` method in the ``ExchangeRatesParser`` class  to ``ParseDocument(XDocument)`` or something similar to avoid confusion since there are many Parse method overloads in the class.